### PR TITLE
xclip support

### DIFF
--- a/src/puush.py
+++ b/src/puush.py
@@ -6,6 +6,7 @@ import StringIO
 import gtk
 import os
 import pynotify
+import subprocess
 
 NO_INTERNET = False
 
@@ -53,10 +54,14 @@ def _postSS(screenshot):
 	_notify(link[10:len(link) - 11])
 
 def _notify(link):
-	clip = gtk.clipboard_get ('CLIPBOARD')
-
-	clip.set_text(link, -1)
-	clip.store()
+	try:
+		cmd='echo ' + link.strip()+'| xclip -selection c.'
+		subprocess.check_call(cmd, shell=True)
+	# The error for 'command not found' is subprocess.CalledProcessError
+	except Exception as e:
+		clip = gtk.clipboard_get ('CLIPBOARD')
+		clip.set_text(link, -1)
+		clip.store()
 
 	if pynotify.init("puush"):
 


### PR DESCRIPTION
Right, I didn't know how to test for `gtk.Clipboard` in a clean way because it didn't return any errors, so I made it so it tries with `xclip` first. Also, it checks for most exceptions, not only for `command not found` as I wasn't sure if that's comprehensive enough.

Feel free to disregard the changes or modify them as you wish.
